### PR TITLE
Respect target Configuration

### DIFF
--- a/.github/workflows/release-container.yaml
+++ b/.github/workflows/release-container.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'sandbox'
     paths-ignore:
       - "**.md"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 If you are trying to use `quadit` and run into an issue- please file an
 issue! We'd love to get you up and running, even if the issue you have might
 not be directly related to the code in `quadit`. This tool seeks to make
-getting a project in Rust easy to start, so any sorts of feedback on usability,
+getting containers running on edge devices simple, so any sorts of feedback on usability,
 usecases, or other aspects of this general problem space are welcome!
 
 When filing an issue, do your best to be as specific as possible. Include
@@ -17,61 +17,47 @@ faster was can reproduce your issue, the faster we can fix it for you!
 
 ### Unit tests
 
-After writing your patch, or finishing an awesome feature, make sure that your
-code does not collides with the existing code, in executing the unit tests.
+After writing your patch, or finishing a feature, make sure that your
+code does not collides with the existing code by executing the unit tests.
 
-To execute the unit tests, we will use the `test` feature included in `cargo`:
+To execute the tests performed in the CI environment use the following features included in cargo:
 
 ```sh
 cargo test
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
 ```
 
 `cargo test` will execute the unit tests included in the `tests` directory.
-If all the lights are green, you can then validate the manual tests.
+If all the lights are green then you will want to execute .
 
-### Manual tests
+`cargo fmt` will ensure all your code is formatted correctly. [See Configuring rustfmt](#configuring-rustfmt) for set up.
 
-For complex issues, and solutions, we did not created unit tests yet.
-Otherwise, we have manual tests in order to check if everything is ok.
+`cargo clippy` enforces Rust community best practices on code structure. 
 
-For example, to test if your code does not collides with the solution of the
-[issue #83], you have to run those tests locally:
+### Commits 
 
-**1. Clone an existing template, without any git submodule, locally**
+All commits **MUST** be signed with a [Developer Certificate of Origin](https://developercertificate.org/).
 
-You can take one at the [Templates page].
-For example:
-
-```sh
-cargo generate --git https://github.com/rustwasm/wasm-pack-template
+This is usually done by adding the `-s` flag to the commit command. 
+```
+git commit -s -m"feat: a rad feature"
 ```
 
-Once you tested the project has been correctly cloned and set, please to
-do the same with a template that contains git submodules.
+This isn't negotiable but if you forget to add it the error in the CI will provide guidance on how you can apply it retrospectively. 
 
-**2. Clone an existing template, with at least one git submodule, locally**
-
-For example:
-
-```sh
-cargo generate --git https://github.com/k0pernicus/cargo-template-test-submodule
-```
-
-Please check that the project has been correctly cloned and set, and check
-if the repository contains initialized submodules.
-
-**Your ideas/contributions are welcome to create automated tests for this** :)
+We like [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and would encourage regular committers to use it.
 
 ## Submitting a PR
 
 If you are considering filing a pull request, make sure that there's an issue
 filed for the work you'd like to do. There might be some discussion required!
 Filing an issue first will help ensure that the work you put into your pull
-request will get merged :)
+request will get merged.
 
 Before you submit your pull request, check that you have completed all of the
 steps mentioned in the pull request template. Link the issue that your pull
-request is responding to, and format your code using [rustfmt][rustfmt].
+request is responding to, and run the commands outlined in the [unit test section](#unit-tests).
 
 ### Configuring rustfmt
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,6 +1001,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "users",
  "uuid",
 ]
 
@@ -1683,6 +1684,16 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "quadit"
-version = "0.1.6"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,10 +688,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1090,9 +1091,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254"
 dependencies = [
  "base64",
  "bytes",
@@ -1205,6 +1206,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
@@ -1487,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.0"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1710,9 +1717,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.15.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.1",
 ]
@@ -1755,23 +1762,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1792,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1802,9 +1810,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1815,9 +1823,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
@@ -1868,32 +1879,31 @@ checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-registry"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1947,11 +1957,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1967,6 +1993,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,6 +2009,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1991,10 +2029,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2009,6 +2059,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,6 +2075,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2033,6 +2095,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,6 +2111,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tracing-subscriber = { version = "0.3.19", features = [
     "env-filter",
 ] }
 url = "2.5.4"
+users = "0.11"
 reqwest = "0.12.12"
 dirs = "6.0.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quadit"
-version = "0.1.6"
+version = "1.0.0"
 description = "A gitops tool to deploy systemd managed containers on linux using quadlets"
 authors = ["Anton Whalley <antonwhalley@yahoo.com>"]
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ quaditsync = "1.0.2"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_yaml = "0.9.34"
 tokio-cron-scheduler = "0.13.0"
-uuid = "1.15.1"
-tokio = { version = "1.44.0", features = ["macros", "rt-multi-thread"] }
+uuid = "1.16.0"
+tokio = { version = "1.44.1", features = ["macros", "rt-multi-thread"] }
 dotenvy = "0.15.7"
 chrono = "0.4.40"
 tracing = { version = "0.1.41", features = ["log"] }
@@ -25,7 +25,7 @@ tracing-subscriber = { version = "0.3.19", features = [
 ] }
 url = "2.5.4"
 users = "0.11"
-reqwest = "0.12.12"
+reqwest = "0.12.14"
 dirs = "6.0.0"
 
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For more detail on quadlet see [this article](https://www.redhat.com/sysadmin/qu
 
 ## features
 
-`quadit` is a very opinionated reimplementation of the fantastic [fetchit](https://github.com/containers/fetchit) podman management system. 
+`quadit` is an opinionated reimplementation of the fantastic [fetchit](https://github.com/containers/fetchit) podman management system. 
 
 Please evaluate the following matrix to understand which one would better suit your needs.
 
@@ -26,13 +26,12 @@ Please evaluate the following matrix to understand which one would better suit y
 |---|---|---|---|
 |simple file transfer|yes|no|May be considered as a feature if required|
 |ansible|yes|no|Not a quadit goal|
-|kube|yes|no|Raw yaml files are not a quadit goal|
 |raw|yes|no|Not a quadit goal|
 |plain systemd files|yes|no|May be considered as a feature if required|
 |user quadlet|no|yes|Not available in fetchit [See fetchit issue](https://github.com/containers/fetchit/issues/311)|
 |root quadlet|no|no|May be considered as a feature if required|
 |systemd stop|no|yes|[Code exists](https://github.com/containers/fetchit/blob/main/method_containers/systemd/systemd-script#L51) in fetchit but not surfaced in config|
-|systemd start|no|yes|Not implemented in `fetchit`|
+|systemd start|no|yes|Not implemented in `fetchit` at time of writing|
 |auto-update|yes|no|quadit is targeting auto configuration but work is yet to commence|
 |.kube|no|yes|Standard quadlet file type|
 |.volume|no|yes|Standard quadlet file type|
@@ -57,30 +56,36 @@ systemctl --user start quadit
 ### environment variables
 None of these environment variables should need tweaking but the options are documented as they are available.
 
-|Name|Default|Description|
+|Name|Required|Default|Description|
 |---|---|---|
-|BOOT_URL|<Empty>|Bootstrap the service from remote `config.yaml` hosted at a url. Overrides the local `config.yaml`| 
-|LOCAL|'no'|If set to a 'yes' then the exe will assume it's not in a container and run with the local users configuration from $HOME and not use `/opt` locations| 
-|PODMAN_UNIT_PATH|`$HOME/.config/containers/systemd`|The location where the container files should be written on the host machine|
-|JOB_PATH|<Empty>|Left empty for testing but set to `/tmp` in the `quadit.container` file|
-|JOB_FOLDER|`jobs`|The name of the folder to save jobs.|
-|XDG_RUNTIME_DIR|`/run/user/%U`|Used by systemd to find a user-specific directory in which it can store small temporary files|
-|HOME|%u|Set by systemd parameter `%u` but can be overridden in the `quadit.container` file|
-|PODMAN_SYSTEMD_UNIT|%n|Set by systemd - the name of the unit|
-|LOG_LEVEL|`info`| Can be `error`, `warn`, `info`, `debug`, `trace`|
-|SYSTEMCTL_PATH|`/usr/bin/systemctl`|Path to the `systemctl` binary|
+|
+|BOOT_URL|NO|<Empty>|Bootstrap the service from remote `config.yaml` hosted at a url. Overrides the local `config.yaml`| 
+|LOCAL|NO|`no`|If set to a 'yes' then the exe will assume it's not in a container and run with the local users configuration for `$HOME` and not use `/opt` locations| 
+|LOG_LEVEL|NO|`info`| Can be `error`, `warn`, `info`, `debug`, `trace`|
+|JOB_PATH|NO|<Empty>|Left empty for testing but in deployment it's set to `/tmp` in the `quadit.container` file|
+|JOB_FOLDER|NO|`jobs`|The name of the folder to save jobs.|
+|PODMAN_UNIT_PATH|NO|`$HOME/.config/containers/systemd`|The location where the container files should be written on the host machine|
+|HOME|NO|%u|Set by systemd parameter `%u` but can be overridden in the `quadit.container` file|
+|XDG_RUNTIME_DIR|NO|`/run/user/%U`|Used by systemd to find a user-specific directory in which it can store small temporary files. Sometimes not available in headless environments
+|PODMAN_SYSTEMD_UNIT|NO|%n|Set by systemd - the name of the unit|
 
-## Supported Versions
+|SYSTEMCTL_PATH|NO|`/usr/bin/systemctl`|Path to the `systemctl` binary|
 
-* podman >= 4.8.3
-* fedora >= 39
-* Red Hat Enterprise Linux >= 8
+## Support
+
+This project is kindly sponsored by [Mehal Technologies](https://mehal.tech) and they offer commercial support for this software as well as providing cloud services to deliver advanced GitOps use cases. 
+
+The project follows latest in all downstream dependencies. 
+
+We won't intentionally break compatibility on new versions and we are happy to receive changes from the community to provide backwards compatibility but the project will prioritize new capabilities over backwards compatibility where a decision needs to be made.  
+
+The current list of downstream OS service dependencies is:  
+* podman >= 5.4.0
+* fedora >= 41
+* Red Hat Enterprise Linux >= 9
 * ubuntu >= 22.04
 
-## development service
-```
-cargo install quadit
-```
+**N.B This list is updated per release**
 
 ## License
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 60%    # the required coverage value
+        threshold: 1%  # the leniency in hitting the target
+    patch:
+      default:
+        informational: true
+  ignore:
+    - "tests"  # ignore tests themselves but who watches the watchmen ;)
+    - "**/main.rs" # ignore main as it's covered in units

--- a/src/file_manager.rs
+++ b/src/file_manager.rs
@@ -20,6 +20,7 @@ const SUPPORTED_FILES: [&str; 5] = ["container", "volume", "pod", "network", "ku
 pub struct FileManager {}
 
 impl FileManager {
+    /// Gets the boot url that's shared across the different threads in the service  
     pub fn boot_url() -> &'static str {
         static BOOT_URL: OnceLock<String> = OnceLock::new();
         BOOT_URL.get_or_init(|| var("BOOT_URL").unwrap_or("".to_string()))
@@ -336,7 +337,7 @@ impl FileManager {
         })
     }
 
-    fn get_unit_path() -> PathBuf {
+    pub fn get_unit_path() -> PathBuf {
         if FileManager::is_local() == "yes" {
             let mut config_path = match dirs::home_dir() {
                 Some(p) => p,
@@ -349,148 +350,5 @@ impl FileManager {
             config_path.push("/opt/containers");
             config_path
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::{
-        env,
-        fs::{self, File, OpenOptions},
-        path::PathBuf,
-    };
-
-    use tracing::error;
-
-    use super::FileManager;
-
-    #[test]
-    fn test_are_identical() {
-        let file_name1 = "Cargo.toml";
-        let file_name2 = "Cargo.toml";
-
-        assert!(FileManager::are_identical(file_name1, file_name2));
-    }
-    #[test]
-    fn test_are_not_identical() {
-        let file_name1 = "README.md";
-        let file_name2 = "Cargo.toml";
-
-        assert!(!FileManager::are_identical(file_name1, file_name2));
-    }
-
-    #[test]
-    fn test_deploy_unit_file() {
-        // Arrange
-        let jobdir = "/tmp/test_deploy_container_file_job";
-        let target_path = "test.container";
-        fs::create_dir(jobdir).unwrap();
-
-        let mut unit_path = FileManager::get_unit_path();
-        if !unit_path.exists() {
-            let dir = unit_path.clone();
-            fs::create_dir_all(dir).unwrap_or_else(|why| {
-                error!("! {:?}", why.kind());
-            });
-        }
-        unit_path.push(target_path);
-
-        let file_path: PathBuf = [jobdir, "test.container"].iter().collect();
-        let rm_file_path: PathBuf = [jobdir, "test.container"].iter().collect();
-        File::create(file_path).unwrap();
-
-        // Act
-        let s: String = FileManager::deploy_unit_file(jobdir, target_path).unwrap();
-        println!("{}", unit_path.as_path().display());
-        println!("{}", s);
-
-        // Assert
-        assert!(unit_path.exists());
-        let deployed_unit_path: PathBuf = [s].iter().collect();
-        assert!(deployed_unit_path.exists(), "Unit path wasn't deployed");
-
-        // Tidy
-        fs::remove_file(rm_file_path).unwrap();
-        fs::remove_dir(jobdir).unwrap();
-        fs::remove_file(unit_path).unwrap();
-    }
-
-    #[test]
-
-    fn test_deploy_unit_folder_job() {
-        // Arrange
-        let jobdir = "/tmp/test_deploy_unit_folder_job";
-        let target_path = "samples/helloworld";
-        let full_job_folder = "/tmp/test_deploy_unit_folder_job/samples/helloworld";
-        let file_path: PathBuf = [jobdir, "samples/helloworld", "test.container"]
-            .iter()
-            .collect();
-        let rm_file_path: PathBuf = [jobdir, "samples/helloworld", "test.container"]
-            .iter()
-            .collect();
-
-        fs::create_dir_all(full_job_folder).unwrap();
-        File::create(&file_path).unwrap();
-        let mut unit_path = FileManager::get_unit_path();
-        if !unit_path.exists() {
-            let dir = unit_path.clone();
-            fs::create_dir_all(dir).unwrap_or_else(|why| {
-                error!("! {:?}", why.kind());
-            });
-        }
-        unit_path.push(target_path);
-
-        println!(
-            "Simulating downloaded file: {}",
-            &file_path.as_path().display()
-        );
-
-        let _ = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(file_path);
-
-        // Act
-        let s = FileManager::deploy_unit_file(jobdir, "samples/helloworld/test.container").unwrap();
-        println!("{}", unit_path.as_path().display());
-        println!("{}", s);
-
-        // Assert
-        assert!(unit_path.exists());
-        assert_eq!(
-            s,
-            "/opt/containers/samples/helloworld/test.container".to_string(),
-            "Deployed unit location is incorrect"
-        );
-        let deployed_unit_path: PathBuf = [s].iter().collect();
-        assert!(deployed_unit_path.exists(), "Unit path wasn't deployed");
-        // Clean Up
-        fs::remove_file(&rm_file_path).unwrap();
-        fs::remove_dir(full_job_folder).unwrap();
-    }
-
-    #[test]
-    fn test_container_file_to_unit_name() {
-        let original = "sample/test.container".to_string();
-        let expected = "test.service".to_string();
-        let resp = FileManager::filename_to_unit_name(&original);
-
-        assert_eq!(expected, resp.unwrap());
-    }
-
-    #[test]
-    fn test_default_podman_unit_location() {
-        assert_eq!(
-            FileManager::podman_unit_path(),
-            ".config/containers/systemd",
-            "Unexpected podman unit defaults"
-        );
-    }
-
-    #[test]
-    fn test_setting_boot_url() {
-        env::set_var("BOOT_URL", "iamset");
-        assert_eq!(FileManager::boot_url(), "iamset", "Unexpected boot url");
     }
 }

--- a/src/file_manager.rs
+++ b/src/file_manager.rs
@@ -188,15 +188,15 @@ impl FileManager {
     /// Currently `~/.config/containers/systemd/` but this may be expanded in later releases.
     /// # Arguments
     /// `job_path` - The path to the job - Usually `jobs/xxxxxxxx-xxxx-4xxx-Nxxx-xxxxxxxxxxxx`.
-    /// `target_path` - The path of the file in the git repo  
+    /// `unit_path` - The path of the file in the git repo  
     #[instrument(level = "trace")]
-    pub fn container_file_deployed(job_path: &str, target_path: &str) -> bool {
+    pub fn is_unit_file_deployed(job_path: &str, unit_path: &str) -> bool {
         let mut definition_path = PathBuf::new();
         definition_path.push(job_path);
-        definition_path.push(target_path);
+        definition_path.push(unit_path);
 
-        let path = Path::new(target_path);
-        let mut config_path = FileManager::get_container_path();
+        let path = Path::new(unit_path);
+        let mut config_path = FileManager::get_unit_path();
 
         config_path.push(path.file_name().unwrap_or_default());
 
@@ -272,14 +272,12 @@ impl FileManager {
     ///
     /// # Arguments
     /// `job_path` - The location that the repo has been copied to
-    /// `target_path` - The location of the .container file in the repo
+    /// `repo_unit_path` - The location of the .container file in the repo
     #[instrument(level = "trace")]
-    pub fn deploy_container_file(job_path: &str, target_path: &str) -> Result<String, String> {
-        let path = Path::new(target_path);
-
+    pub fn deploy_unit_file(job_path: &str, repo_unit_path: &str) -> Result<String, String> {
         let mut definition_path = PathBuf::new();
         definition_path.push(job_path);
-        definition_path.push(target_path);
+        definition_path.push(repo_unit_path);
         if !SUPPORTED_FILES.contains(
             &definition_path
                 .extension()
@@ -289,20 +287,24 @@ impl FileManager {
         ) {
             let msg = format!(
                 "File MUST be a valid quadlet file. e.g. .container, .volume, .pod, .network, .kube.  Found: {}",
-                target_path
+                repo_unit_path
             );
             return Err(msg);
         }
-        let mut cont_path = FileManager::get_container_path();
-        cont_path.push(path.file_name().unwrap_or_default());
+        let mut unit_deploy_path = FileManager::get_unit_path();
+        println!("repo_unit_path: {}", repo_unit_path);
+        unit_deploy_path.push(repo_unit_path);
+        //cont_path.push(path.file_name().unwrap_or_default());
+        println!("unit_deploy_path: {:#?}", unit_deploy_path);
+        println!("definition_path: {:#?}", definition_path);
 
-        let cpath = cont_path.clone();
+        let cpath = unit_deploy_path.clone();
         let dpath = definition_path.clone();
-        match fs::copy(definition_path, cont_path) {
+        match fs::copy(definition_path, unit_deploy_path) {
             Ok(_) => {}
             Err(e) => {
                 let msg = format!(
-                    "Failed to copy {:?} to {:?}. {}",
+                    "deploy_unit_file: Failed to copy {:?} to {:?}. {}",
                     dpath.to_str(),
                     cpath.to_str(),
                     e
@@ -316,7 +318,7 @@ impl FileManager {
         Ok(cpath.as_path().display().to_string())
     }
 
-    fn get_container_path() -> PathBuf {
+    fn get_unit_path() -> PathBuf {
         if FileManager::is_local() == "yes" {
             let mut config_path = match dirs::home_dir() {
                 Some(p) => p,
@@ -339,6 +341,8 @@ mod tests {
         path::PathBuf,
     };
 
+    use tracing::error;
+
     use super::FileManager;
 
     #[test]
@@ -357,31 +361,31 @@ mod tests {
     }
 
     #[test]
-    fn test_deploy_container_file() {
+    fn test_deploy_unit_file() {
         let jobdir = "/tmp/test_deploy_container_file_job";
         let target_path = "test.container";
         fs::create_dir(jobdir).unwrap();
 
-        let mut cont_path = FileManager::get_container_path();
-        if !cont_path.exists() {
-            let dir = cont_path.clone();
+        let mut unit_path = FileManager::get_unit_path();
+        if !unit_path.exists() {
+            let dir = unit_path.clone();
             fs::create_dir_all(dir).unwrap_or_else(|why| {
-                println!("! {:?}", why.kind());
+                error!("! {:?}", why.kind());
             });
         }
-        cont_path.push(target_path);
+        unit_path.push(target_path);
 
         let file_path: PathBuf = [jobdir, "test.container"].iter().collect();
         let rm_file_path: PathBuf = [jobdir, "test.container"].iter().collect();
         File::create(file_path).unwrap();
 
-        let s = FileManager::deploy_container_file(jobdir, target_path).unwrap();
-        println!("{}", cont_path.as_path().display());
+        let s = FileManager::deploy_unit_file(jobdir, target_path).unwrap();
+        println!("{}", unit_path.as_path().display());
         println!("{}", s);
-        assert!(cont_path.exists());
+        assert!(unit_path.exists());
         fs::remove_file(rm_file_path).unwrap();
         fs::remove_dir(jobdir).unwrap();
-        fs::remove_file(cont_path).unwrap();
+        fs::remove_file(unit_path).unwrap();
     }
 
     #[test]

--- a/src/file_manager.rs
+++ b/src/file_manager.rs
@@ -329,7 +329,7 @@ impl FileManager {
         Ok(upath.as_path().display().to_string())
     }
 
-    fn podman_unit_path() -> &'static str {
+    pub fn podman_unit_path() -> &'static str {
         static PODMAN_UNIT_PATH: OnceLock<String> = OnceLock::new();
         PODMAN_UNIT_PATH.get_or_init(|| {
             var("PODMAN_UNIT_PATH").unwrap_or(".config/containers/systemd".to_string())
@@ -355,6 +355,7 @@ impl FileManager {
 #[cfg(test)]
 mod tests {
     use std::{
+        env,
         fs::{self, File, OpenOptions},
         path::PathBuf,
     };
@@ -476,5 +477,20 @@ mod tests {
         let resp = FileManager::filename_to_unit_name(&original);
 
         assert_eq!(expected, resp.unwrap());
+    }
+
+    #[test]
+    fn test_default_podman_unit_location() {
+        assert_eq!(
+            FileManager::podman_unit_path(),
+            ".config/containers/systemd",
+            "Unexpected podman unit defaults"
+        );
+    }
+
+    #[test]
+    fn test_setting_boot_url() {
+        env::set_var("BOOT_URL", "iamset");
+        assert_eq!(FileManager::boot_url(), "iamset", "Unexpected boot url");
     }
 }

--- a/src/git_manager.rs
+++ b/src/git_manager.rs
@@ -282,9 +282,21 @@ impl GitManager {
             match FileManager::get_files_in_directory(full_job_path.to_str().unwrap_or_default()) {
                 Ok(file_names) => {
                     for file_name in file_names {
-                        let file_path =
-                            format!("{}/{}", full_job_path.as_path().display(), file_name);
-                        GitManager::process_repo("", &file_path, uuid);
+                        // job_path is job_path
+                        let mut full_config_target_path = PathBuf::new();
+                        full_config_target_path.push(config_target_path);
+                        full_config_target_path.push(file_name);
+                        // let file_path =
+                        //     format!("{}/{}", full_config_target_path.as_path().display(), file_name);
+                        GitManager::process_repo(
+                            job_path,
+                            full_config_target_path
+                                .as_path()
+                                .display()
+                                .to_string()
+                                .as_str(),
+                            uuid,
+                        );
                     }
                 }
                 Err(e) => error!("{}: Error: {}", uuid, e),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,27 @@
 use std::{env, str::FromStr};
 
 use anyhow::Result;
-use tracing::Level;
+use tracing::{warn, Level};
 use tracing_subscriber::FmtSubscriber;
 
 use quadit::service_manager::ServiceManager;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    if users::get_current_uid() == 0 {
+        warn!(
+            r#"
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+quadit running with root permissions
+This isn't currently supported and
+May lead to security problems and 
+undefined behaviour
+See 
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+"#
+        );
+    }
+
     if dotenvy::dotenv().is_ok() {
         println!("Using .env")
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ quadit running with root permissions
 This isn't currently supported and
 May lead to security problems and 
 undefined behaviour
-See 
+See https://github.com/ubiquitous-factory/quadit/issues/76
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 "#
         );

--- a/src/service_manager.rs
+++ b/src/service_manager.rs
@@ -79,9 +79,6 @@ impl ServiceManager {
         if FileManager::boot_url().is_empty() {
             FileManager::from_url(FileManager::boot_url()).await?;
         }
-        // let serviceconf = FileManager::load_quadit_config()?;
-        // let quadit = QuaditManager::from_yaml(serviceconf).await?;
-        // quadit.start().await?;
         loop {
             std::thread::sleep(Duration::from_millis(100));
         }

--- a/tests/file_manager.rs
+++ b/tests/file_manager.rs
@@ -1,0 +1,141 @@
+#[cfg(test)]
+mod tests {
+    use std::{
+        env,
+        fs::{self, File, OpenOptions},
+        path::PathBuf,
+    };
+
+    use quadit::file_manager::FileManager;
+    use tracing::error;
+
+    #[test]
+    fn test_are_identical() {
+        let file_name1 = "Cargo.toml";
+        let file_name2 = "Cargo.toml";
+
+        assert!(FileManager::are_identical(file_name1, file_name2));
+    }
+    #[test]
+    fn test_are_not_identical() {
+        let file_name1 = "README.md";
+        let file_name2 = "Cargo.toml";
+
+        assert!(!FileManager::are_identical(file_name1, file_name2));
+    }
+
+    #[test]
+    fn test_deploy_unit_file() {
+        // Arrange
+        let jobdir = "/tmp/test_deploy_container_file_job";
+        let target_path = "test.container";
+        fs::create_dir(jobdir).unwrap();
+
+        let mut unit_path = FileManager::get_unit_path();
+        if !unit_path.exists() {
+            let dir = unit_path.clone();
+            fs::create_dir_all(dir).unwrap_or_else(|why| {
+                error!("! {:?}", why.kind());
+            });
+        }
+        unit_path.push(target_path);
+
+        let file_path: PathBuf = [jobdir, "test.container"].iter().collect();
+        let rm_file_path: PathBuf = [jobdir, "test.container"].iter().collect();
+        File::create(file_path).unwrap();
+
+        // Act
+        let s: String = FileManager::deploy_unit_file(jobdir, target_path).unwrap();
+        println!("{}", unit_path.as_path().display());
+        println!("{}", s);
+
+        // Assert
+        assert!(unit_path.exists());
+        let deployed_unit_path: PathBuf = [s].iter().collect();
+        assert!(deployed_unit_path.exists(), "Unit path wasn't deployed");
+
+        // Tidy
+        fs::remove_file(rm_file_path).unwrap();
+        fs::remove_dir(jobdir).unwrap();
+        fs::remove_file(unit_path).unwrap();
+    }
+
+    #[test]
+
+    fn test_deploy_unit_folder_job() {
+        // Arrange
+        let jobdir = "/tmp/test_deploy_unit_folder_job";
+        let target_path = "samples/helloworld";
+        let full_job_folder = "/tmp/test_deploy_unit_folder_job/samples/helloworld";
+        let file_path: PathBuf = [jobdir, "samples/helloworld", "test.container"]
+            .iter()
+            .collect();
+        let rm_file_path: PathBuf = [jobdir, "samples/helloworld", "test.container"]
+            .iter()
+            .collect();
+
+        fs::create_dir_all(full_job_folder).unwrap();
+        File::create(&file_path).unwrap();
+        let mut unit_path = FileManager::get_unit_path();
+        if !unit_path.exists() {
+            let dir = unit_path.clone();
+            fs::create_dir_all(dir).unwrap_or_else(|why| {
+                error!("! {:?}", why.kind());
+            });
+        }
+        unit_path.push(target_path);
+
+        println!(
+            "Simulating downloaded file: {}",
+            &file_path.as_path().display()
+        );
+
+        let _ = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(file_path);
+
+        // Act
+        let s = FileManager::deploy_unit_file(jobdir, "samples/helloworld/test.container").unwrap();
+        println!("{}", unit_path.as_path().display());
+        println!("{}", s);
+
+        // Assert
+        assert!(unit_path.exists());
+        assert_eq!(
+            s,
+            "/opt/containers/samples/helloworld/test.container".to_string(),
+            "Deployed unit location is incorrect"
+        );
+        let deployed_unit_path: PathBuf = [s].iter().collect();
+        assert!(deployed_unit_path.exists(), "Unit path wasn't deployed");
+        // Clean Up
+        fs::remove_file(&rm_file_path).unwrap();
+        fs::remove_dir(full_job_folder).unwrap();
+    }
+
+    #[test]
+    fn test_container_file_to_unit_name() {
+        let original = "sample/test.container".to_string();
+        let expected = "test.service".to_string();
+        let resp = FileManager::filename_to_unit_name(&original);
+
+        assert_eq!(expected, resp.unwrap());
+    }
+
+    #[test]
+    fn test_default_podman_unit_location() {
+        assert_eq!(
+            FileManager::podman_unit_path(),
+            ".config/containers/systemd",
+            "Unexpected podman unit defaults"
+        );
+    }
+
+    #[test]
+    fn test_set_boot_url() {
+        env::set_var("BOOT_URL", "iamset");
+        assert_eq!(FileManager::boot_url(), "iamset", "Unexpected boot url");
+    }
+}

--- a/tests/file_manager_standalone.rs
+++ b/tests/file_manager_standalone.rs
@@ -1,0 +1,13 @@
+use std::env;
+
+use quadit::file_manager::FileManager;
+
+#[test]
+fn test_set_podman_unit_location() {
+    env::set_var("PODMAN_UNIT_PATH", "iamset");
+    assert_eq!(
+        FileManager::podman_unit_path(),
+        "iamset",
+        "Unexpected podman unit"
+    );
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -13,7 +13,12 @@ mod test {
     use std::{env, path::PathBuf};
 
     use tokio_cron_scheduler::JobScheduler;
+
+    #[cfg(test)]
+    use std::println as info;
+    #[cfg(not(test))]
     use tracing::info;
+
     // Needs multi_thread to test, otherwise it hangs on scheduler.add()
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 
@@ -22,7 +27,7 @@ mod test {
         let uloc = "/tmp/quadit_test/.config/containers/systemd";
         env::set_var("JOB_PATH", "/tmp/quadit_test");
         env::set_var("PODMAN_UNIT_PATH", uloc);
-
+        env::set_var("LOCAL", "yes");
         fs::remove_dir_all(uloc).unwrap_or_default();
 
         fs::create_dir_all("/tmp/quadit_test/.config/containers/systemd").unwrap();
@@ -63,5 +68,12 @@ mod test {
         let mut p = PathBuf::new();
         p.push(uloc);
         assert!(p.exists());
+
+        let testfile =
+            "/tmp/quadit_test/.config/containers/systemd/samples/helloworld/hello.container";
+
+        let mut testfilepath = PathBuf::new();
+        testfilepath.push(testfile);
+        assert!(testfilepath.exists());
     }
 }


### PR DESCRIPTION
As per the discussion in https://github.com/ubiquitous-factory/quadit/issues/73 
This PR now ensures the units copied to the systemd folder are prefixed by the `targetConfig` location as a directory structure. 
e.g. 
```yaml
targetConfigs:
- url: https://github.com/ubiquitous-factory/quadit
  targetPath: "samples/helloworld"
  branch: "main"
  schedule: "1/10 * * * * *"
```
Will now deploy the file to `$HOME/.config/containers/systemd/samples/helloworld`

This is a breaking change to the major version has been bumped to 1.0.0